### PR TITLE
Use Torrent File Trackers when Available

### DIFF
--- a/enginefs.js
+++ b/enginefs.js
@@ -80,6 +80,8 @@ function createEngine(infoHash, options, cb)
     if (isNew && options.peerSearch) {
         var peerSources = []
 
+        // torrent can be an object or a string and we need this to be foolproof, the only way
+        // this condition will fail is if torrent.announce is a string, which should not be possible
         if (((torrent || {}).announce || []).length) {
             peerSources = peerSources
                             .concat(torrent.announce)

--- a/enginefs.js
+++ b/enginefs.js
@@ -77,7 +77,19 @@ function createEngine(infoHash, options, cb)
     // needed for stats
     e.options = options; 
 
-    if (isNew && options.peerSearch) new PeerSearch(options.peerSearch.sources, e.swarm, options.peerSearch);
+    if (isNew && options.peerSearch) {
+        var peerSources = []
+
+        if (((torrent || {}).announce || []).length) {
+            peerSources = peerSources
+                            .concat(torrent.announce)
+                            .map(function(src) { return 'tracker:' + src })
+                            .concat('dht:' + infoHash)
+        } else
+            peerSources = options.peerSearch.sources
+
+        new PeerSearch(peerSources, e.swarm, options.peerSearch);
+    }
     if (isNew && options.swarmCap) {
         var updater = updateSwarmCap.bind(null, e, options.swarmCap);
         e.swarm.on("wire", updater);


### PR DESCRIPTION
Related to this issue: https://github.com/Stremio/stremio/issues/1019

Trackers for torrent files were not used when creating a torrent stream instance.