### PR TITLE
Fix For Remove Engine Logic in TV Env

### DIFF
--- a/enginefs.js
+++ b/enginefs.js
@@ -170,11 +170,17 @@ function existsEngine(infoHash)
     return !!engines[infoHash.toLowerCase()]; 
 }
 
-function removeEngine(infoHash)
+function removeEngine(infoHash, cb)
 {
-    if (!engines[infoHash]) return;
-    engines[infoHash].destroy(function() { Emit(["engine-destroyed", infoHash]) });
-    delete engines[infoHash];
+    if (!existsEngine(infoHash)) {
+        if (cb) cb()
+        return;
+    }
+    engines[infoHash.toLowerCase()].destroy(function() {
+        Emit(["engine-destroyed", infoHash])
+        delete engines[infoHash.toLowerCase()];
+        if (cb) cb();
+    });
 }
 
 function settingsEngine(infoHash, settings) 
@@ -354,8 +360,9 @@ router.all("/create", function(req, res) {
 });
 
 router.get("/:infoHash/remove", function(req, res) { 
-    removeEngine(req.params.infoHash); 
-    res.writeHead(200, jsonHead); res.end(JSON.stringify({})); 
+    removeEngine(req.params.infoHash, function() {
+        res.writeHead(200, jsonHead); res.end(JSON.stringify({})); 
+    }); 
 });
 router.get("/removeAll", function(req, res) { 
     for (ih in engines) removeEngine(ih);


### PR DESCRIPTION
For TV environment we need to ensure a concurrency of 1 engine instance, this is so we can always delete the full cache of all previous engine instances. (because there is drastically low disk space on these devices)